### PR TITLE
:arrow_down: ampersand-state ^4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "ampersand-model": "^6.0.2",
     "ampersand-rest-collection": "^5.0.0",
-    "ampersand-state": "^4.7.0",
+    "ampersand-state": "^4.6.0",
     "async": "^1.5.0",
     "debug": "^2.2.0",
     "mongodb-collection-model": "^0.1.1",


### PR DESCRIPTION
Don't force "ampersand-state": "^4.7.0", permit 4.6.0.
