### PR TITLE
INT-973 detect enterprise module for versions < 3.1.3

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -53,6 +53,10 @@ function parseBuildInfo(resp) {
     max_bson_object_size: resp.maxBsonObjectSize,
     enterprise_module: false
   };
+  // cover both cases of detecting enterprise module, see SERVER-18099
+  if (resp.gitVersion.match(/enterprise/)) {
+    res.enterprise_module = true;
+  }
   if (resp.modules && resp.modules.indexOf('enterprise') !== -1) {
     res.enterprise_module = true;
   }

--- a/test/fetch-mocked.test.js
+++ b/test/fetch-mocked.test.js
@@ -55,6 +55,26 @@ describe('unit tests on fetch functions', function() {
         done();
       }, results);
     });
+    it('should detect enterprise module correctly for 2.6 and 3.0', function(done) {
+      var results = {
+        db: makeMockDB(null, fixtures.BUILD_INFO_OLD)
+      };
+      fetch.getBuildInfo(function(err, res) {
+        assert.equal(err, null);
+        assert.equal(res.enterprise_module, true);
+        done();
+      }, results);
+    });
+    it('should detect enterprise module correctly for 3.2 +', function(done) {
+      var results = {
+        db: makeMockDB(null, fixtures.BUILD_INFO_3_2)
+      };
+      fetch.getBuildInfo(function(err, res) {
+        assert.equal(err, null);
+        assert.equal(res.enterprise_module, true);
+        done();
+      }, results);
+    });
   });
 
   describe('getHostInfo', function() {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -377,7 +377,73 @@ var USER_INFO = {
 	]
 };
 
+var BUILD_INFO_OLD = {
+	"version" : "2.6.11",
+	"gitVersion" : "d00c1735675c457f75a12d530bee85421f0c5548 modules: enterprise",
+	"OpenSSLVersion" : "OpenSSL 1.0.1f 6 Jan 2014",
+	"sysInfo" : "Linux ip-10-203-203-194 3.13.0-24-generic #46-Ubuntu SMP Thu Apr 10 19:11:08 UTC 2014 x86_64 BOOST_LIB_VERSION=1_49",
+	"loaderFlags" : "-fPIC -pthread -Wl,-z,now -rdynamic -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -Wl,-E",
+	"compilerFlags" : "-Wnon-virtual-dtor -Woverloaded-virtual -fPIC -fno-strict-aliasing -ggdb -pthread -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -pipe -Werror -O3 -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations -fno-builtin-memcmp",
+	"allocator" : "tcmalloc",
+	"versionArray" : [
+		2,
+		6,
+		11,
+		0
+	],
+	"javascriptEngine" : "V8",
+	"bits" : 64,
+	"debug" : false,
+	"maxBsonObjectSize" : 16777216,
+	"ok" : 1
+};
+
+var BUILD_INFO_3_2 = {
+	"version" : "3.2.0-rc2",
+	"gitVersion" : "8a3acb42742182c5e314636041c2df368232bbc5",
+	"modules" : [
+		"enterprise"
+	],
+	"allocator" : "system",
+	"javascriptEngine" : "mozjs",
+	"sysInfo" : "deprecated",
+	"versionArray" : [
+		3,
+		2,
+		0,
+		-48
+	],
+	"openssl" : {
+		"running" : "OpenSSL 0.9.8zg 14 July 2015",
+		"compiled" : "OpenSSL 0.9.8y 5 Feb 2013"
+	},
+	"buildEnvironment" : {
+		"distmod" : "",
+		"distarch" : "x86_64",
+		"cc" : "gcc: Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)",
+		"ccflags" : "-fno-omit-frame-pointer -fPIC -fno-strict-aliasing -ggdb -pthread -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -Werror -O2 -Wno-unused-function -Wno-unused-private-field -Wno-deprecated-declarations -Wno-tautological-constant-out-of-range-compare -Wno-unused-const-variable -Wno-missing-braces -mmacosx-version-min=10.7 -fno-builtin-memcmp",
+		"cxx" : "g++: Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)",
+		"cxxflags" : "-Wnon-virtual-dtor -Woverloaded-virtual -stdlib=libc++ -std=c++11",
+		"linkflags" : "-fPIC -pthread -Wl,-bind_at_load -mmacosx-version-min=10.7 -stdlib=libc++ -fuse-ld=gold",
+		"target_arch" : "x86_64",
+		"target_os" : "osx"
+	},
+	"bits" : 64,
+	"debug" : false,
+	"maxBsonObjectSize" : 16777216,
+	"storageEngines" : [
+		"devnull",
+		"ephemeralForTest",
+		"inMemory",
+		"mmapv1",
+		"wiredTiger"
+	],
+	"ok" : 1
+};
+
 module.exports = {
   HOST_INFO: HOST_INFO,
-	USER_INFO: USER_INFO
+	USER_INFO: USER_INFO,
+	BUILD_INFO_OLD: BUILD_INFO_OLD,
+	BUILD_INFO_3_2: BUILD_INFO_3_2
 };


### PR DESCRIPTION
Prior to 3.1.3, the `modules` key didn't exist in the `buildInfo` output. Instead, it was appended to the `gitVersion` string as `modules: enterprise`.

Also added new fixtures for old and new buildInfo output and tests.
