### PR TITLE
fix compat changes from lodash upgrade

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -420,9 +420,8 @@ function listCollections(done, results) {
   var databases = results.databases;
 
   // merge and de-dupe databases
-  var dbnames = _.pick(databases, 'name');
-  var tasks = _.map(dbnames, function(name) {
-    return getDatabaseCollections.bind(null, db.db(name));
+  var tasks = _.map(databases, function(_db) {
+    return getDatabaseCollections.bind(null, db.db(_db.name));
   });
 
   async.parallel(tasks, function(err, res) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -112,13 +112,15 @@ var Instance = AmpersandModel.extend({
       props: true,
       derived: true
     }, true);
+
+    var model = this;
     if (this.databases.length > 0) {
-      _.each(this._children, function(value, key) {
-        res[key] = this[key].serialize();
-      }, this);
-      _.each(this._collections, function(value, key) {
-        res[key] = this[key].serialize();
-      }, this);
+      _.each(model._children, function(value, key) {
+        res[key] = model[key].serialize();
+      });
+      _.each(model._collections, function(value, key) {
+        res[key] = model[key].serialize();
+      });
     }
     return res;
   }

--- a/test/fetch-mocked.test.js
+++ b/test/fetch-mocked.test.js
@@ -254,7 +254,7 @@ describe('fetch-mocked', function() {
       ];
     });
 
-    it.skip('should lists all collections for each listable db', function(done) {
+    it('should lists all collections for each listable db', function(done) {
       results.userInfo = fixtures.USER_INFO_JOHN;
       results.db = makeMockDB(null, [{
         'name': 'testCol'

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -14,6 +14,7 @@ describe('mongodb-instance-model#fetch', function() {
   describe('local', function() {
     var db;
     before(function(done) {
+      this.timeout(20000);
       runner.start({}, done);
     });
     after(function() {


### PR DESCRIPTION
`thisArg` is no longer supported in most functions

> Removed thisArg params from most methods because they were largely unused, complicated implementations, & can be tackled with _.bind, Function#bind, or arrow functions

`_.pluck` is no longer supported

> Removed _.pluck in favor of _.map with iteratee shorthand

Enabled skipped test again.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/instance-model/62)

<!-- Reviewable:end -->
