### PR TITLE
COMPASS-100: Return empty user on secondary:

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -314,9 +314,12 @@ function getUserInfo(done, results) {
       usersInfo: user,
       showPrivileges: true
     }, function(_err, _res) {
-      // should always succeed for the logged-in user
       if (_err) {
-        done(_err);
+        // @durran: usersInfo can only be run against a primary - so will always fail here
+        // when connected to a secondary. Since we don't use this information anyways at this
+        // point, will return empty data for the user in the case of the error.
+        debug(`Command 'usersInfo' could not be retrieved: ${_err.message}`);
+        return done(null, {});
       }
       done(null, _res.users[0]);
     });

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -318,7 +318,7 @@ function getUserInfo(done, results) {
         // @durran: usersInfo can only be run against a primary - so will always fail here
         // when connected to a secondary. Since we don't use this information anyways at this
         // point, will return empty data for the user in the case of the error.
-        debug(`Command 'usersInfo' could not be retrieved: ${_err.message}`);
+        debug('Command \"usersInfo\" could not be retrieved: ' + _err.message);
         return done(null, {});
       }
       done(null, _res.users[0]);


### PR DESCRIPTION
- The `usersInfo` command must be run on a primary member of a replica
  set. If we attempt to run this command on a secondary we return an
  empty user instead.
