### PR TITLE
Bump mongodb-ns@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mongodb-collection-model": "^0.3.1",
     "mongodb-database-model": "^0.1.2",
     "mongodb-js-errors": "^0.2.1",
-    "mongodb-ns": "^1.0.1",
+    "mongodb-ns": "^2.0.0",
     "mongodb-security": "^0.0.4",
     "mongodb-url": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "async": "^1.5.2",
     "debug": "^2.2.0",
     "lodash": "^4.10.0",
-    "mongodb-collection-model": "^0.3.1",
+    "mongodb-collection-model": "^0.3.2",
     "mongodb-database-model": "^0.1.2",
     "mongodb-js-errors": "^0.2.1",
     "mongodb-ns": "^2.0.0",


### PR DESCRIPTION
Including the transitive dependency `mongodb-collection-model` and its transitive `mongodb-index-model`.

Note: `npm test` passes for me locally on macOS natively and in an Ubuntu VM, so the mongodb-runner download issue (COMPASS-1217) appears to be Travis-only at this time.