### PR TITLE
Add genuineMongoDB to InstanceModel

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -46,6 +46,13 @@ var BuildInfo = AmpersandState.extend({
   }
 });
 
+var GenuineInfo = AmpersandState.extend({
+  props: {
+    isGenuine: 'boolean',
+    dbType: 'string'
+  }
+});
+
 var Instance = AmpersandModel.extend({
   modelType: 'Instance',
   idAttribute: '_id',
@@ -98,7 +105,8 @@ var Instance = AmpersandModel.extend({
   },
   children: {
     host: HostInfo,
-    build: BuildInfo
+    build: BuildInfo,
+    genuineMongoDB: GenuineInfo
   },
   /**
    * Override `AmpersandModel.serialize()` to

--- a/lib/model.js
+++ b/lib/model.js
@@ -46,7 +46,7 @@ var BuildInfo = AmpersandState.extend({
   }
 });
 
-var GenuineInfo = AmpersandState.extend({
+var genuineMongoDB = AmpersandState.extend({
   props: {
     isGenuine: 'boolean',
     dbType: 'string'
@@ -106,7 +106,7 @@ var Instance = AmpersandModel.extend({
   children: {
     host: HostInfo,
     build: BuildInfo,
-    genuineMongoDB: GenuineInfo
+    genuineMongoDB: genuineMongoDB
   },
   /**
    * Override `AmpersandModel.serialize()` to


### PR DESCRIPTION
Adds a field `genuineMongoDB` to the InstanceModel so the app can know globally if it's connecting to a real MongoDB.

In order to be populated, this needs to be merged: https://github.com/mongodb-js/data-service/pull/142